### PR TITLE
Update Kafka configuration, increase storage size, and enhance scaling functionality

### DIFF
--- a/inter-arrival-collector/collect_inter_arrivals.py
+++ b/inter-arrival-collector/collect_inter_arrivals.py
@@ -27,7 +27,7 @@ class InterArrivalCollector:
         self.monitoring_interval = 5   # Seconds between samples
         
         # ✅ Kafka configuration
-        kafka_host = "kafka-service.oris-predictive-autoscaler.svc.cluster.local:9092"
+        kafka_host = "kafka-service:9092"
         self.kafka_producer = KafkaProducer(
             bootstrap_servers=[kafka_host],
             value_serializer=lambda v: json.dumps(v).encode('utf-8')

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -8,7 +8,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: python-service
 spec:
-  replicas: 1
+  replicas: 5
   selector:
     matchLabels:
       app: python-service

--- a/sirio-controller/Dockerfile
+++ b/sirio-controller/Dockerfile
@@ -1,13 +1,42 @@
-FROM openjdk:26
+########### STAGE 1: Build ###########
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+
+WORKDIR /build
+
+# Copia solo il pom per sfruttare meglio la cache dei layer
+COPY pom.xml .
+# Pre-scarica le dipendenze (usa un pom fittizio se necessario)
+RUN mvn -B -q dependency:resolve dependency:resolve-plugins || true
+
+# Copia il codice sorgente
+COPY src ./src
+
+# Arg per saltare i test opzionalmente (default: esegui test)
+ARG SKIP_TESTS=false
+
+# Compila e crea il jar shaded
+RUN if [ "$SKIP_TESTS" = "true" ]; then \
+			mvn -B -q clean package -DskipTests; \
+		else \
+			mvn -B -q clean package; \
+		fi
+
+########### STAGE 2: Runtime ###########
+FROM eclipse-temurin:21-jre AS runtime
 
 WORKDIR /app
 
-# Copy the already built JAR with the correct name
-COPY target/sirio-controller-1.0-SNAPSHOT.jar sirio-controller-1.0-SNAPSHOT.jar
+# Variabili ambiente (personalizzabili a runtime)
+ENV KAFKA_BOOTSTRAP_SERVERS=kafka-service.oris-predictive-autoscaler.svc.cluster.local:9092 \
+		KAFKA_TOPIC_CDF=inter-arrival-cdf
 
-# Set environment variables for Kafka
-ENV KAFKA_BOOTSTRAP_SERVERS=kafka-service.oris-predictive-autoscaler.svc.cluster.local:9092
-ENV KAFKA_TOPIC_CDF=inter-arrival-cdf
+# Copia il jar dal builder
+COPY --from=build /build/target/sirio-controller-1.0-SNAPSHOT.jar app.jar
 
-# Run the application
-CMD ["java", "-jar", "sirio-controller-1.0-SNAPSHOT.jar"]
+# Migliora l'avvio (Java 21) e dimensioni footprint
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+	CMD ["bash", "-c", "jps >/dev/null 2>&1 || exit 1"]
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/sirio-controller/pom.xml
+++ b/sirio-controller/pom.xml
@@ -73,6 +73,13 @@
         <artifactId>slf4j-simple</artifactId>
         <version>2.0.16</version>
     </dependency>
+
+    <!-- Kubernetes Client -->
+    <dependency>
+        <groupId>io.kubernetes</groupId>
+        <artifactId>client-java</artifactId>
+        <version>20.0.1</version>
+    </dependency>
   </dependencies>
   <build>
       <plugins>
@@ -88,10 +95,20 @@
                         <goal>shade</goal>
                     </goals>
                     <configuration>
+                        <filters>
+                            <filter>
+                                <artifact>*:*</artifact>
+                                <excludes>
+                                    <exclude>META-INF/*.SF</exclude>
+                                    <exclude>META-INF/*.DSA</exclude>
+                                    <exclude>META-INF/*.RSA</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
                         <transformers>
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                 <!-- to check if the java consumer works-->
-                                <mainClass>org.unifi.comunication.InterArrivalKafkaConsumer</mainClass>
+                                <mainClass>org.unifi.App</mainClass>
                                 <!-- To include "normally" -->
                                 <!-- <mainClass>org.unifi.model.App</mainClass> -->
 

--- a/sirio-controller/src/main/java/org/unifi/App.java
+++ b/sirio-controller/src/main/java/org/unifi/App.java
@@ -1,13 +1,26 @@
 package org.unifi;
 
-import org.unifi.model.*;
-import org.unifi.comunication.*;
+import java.io.IOException;
+
+import org.unifi.api.K8sScaler;
+import org.unifi.comunication.InterArrivalKafkaConsumer;
 
 public class App {
     public static void main(String[] args) {
-
-        InterArrivalKafkaConsumer.autoConfig();
-        InterArrivalKafkaConsumer.start_consuming();
-
+            try {
+                
+                K8sScaler scaler = K8sScaler.getInstance();
+                System.out.println("Starting scaler: namespace=" + scaler.getNamespace());
+                
+                try {
+                    scaler.listPods();
+                } catch (Exception e) {
+                    System.err.println("Unable to list all Pods: " + e.getMessage());
+                }
+                
+                InterArrivalKafkaConsumer.autoConfig();
+                InterArrivalKafkaConsumer.start_consuming();
+            } catch (IOException ex) {
+            }
     }
 }

--- a/sirio-controller/src/main/java/org/unifi/api/K8sScaler.java
+++ b/sirio-controller/src/main/java/org/unifi/api/K8sScaler.java
@@ -1,0 +1,116 @@
+package org.unifi.api;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1Scale;
+import io.kubernetes.client.util.ClientBuilder;
+
+public class K8sScaler {
+
+    private final AppsV1Api appsApi;
+    private final CoreV1Api coreApi;
+    private final String namespace;
+    private int replicas;
+    private final String kind;
+    private final String scaleName;
+    private static K8sScaler instance;
+
+    private K8sScaler() throws IOException {
+        ApiClient client = ClientBuilder.cluster().build();
+        Configuration.setDefaultApiClient(client);
+        this.appsApi = new AppsV1Api();
+        this.coreApi = new CoreV1Api();
+        this.namespace = System.getenv().getOrDefault("NAMESPACE", "oris-predictive-autoscaler");
+        this.replicas = 5;
+        this.kind = System.getenv().getOrDefault("KIND", "deployment");
+        this.scaleName = System.getenv().getOrDefault("SCALE_NAME", "python-service");
+    }
+
+    public static K8sScaler getInstance() throws IOException {
+        if (instance == null) {
+            instance = new K8sScaler();
+        }
+        return instance;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public int getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(int replicas) {
+        this.replicas = replicas;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public String getScaleName() {
+        return scaleName;
+    }
+
+    public void listPods() throws ApiException {
+        V1PodList list = coreApi.listNamespacedPod(namespace).execute();
+        System.out.println("Pods in namespace '" + namespace + "' (" + list.getItems().size() + "):");
+        for (V1Pod item : list.getItems()) {
+            System.out.println("- " + item.getMetadata().getName() + " " + item.getStatus().getPhase() + " " + item.getStatus().getPodIP());
+        }
+    }
+
+    public void scaleWorkload() throws ApiException {
+        V1Scale scaleBody = new V1Scale();
+        scaleBody.getSpec().setReplicas(this.replicas);
+
+        switch (kind.toLowerCase()) {
+            case "deployment" -> appsApi.replaceNamespacedDeploymentScale(scaleName, namespace, scaleBody);
+            case "statefulset" -> appsApi.replaceNamespacedStatefulSetScale(scaleName, namespace, scaleBody);
+            case "replicaset" -> appsApi.replaceNamespacedReplicaSetScale(scaleName, namespace, scaleBody);
+            default -> throw new IllegalArgumentException("Kind not supported: " + kind);
+        }
+    }
+
+    public V1Scale readScale() throws ApiException {
+        switch (kind.toLowerCase()) {
+            case "deployment" -> {
+                return appsApi.readNamespacedDeploymentScale(scaleName, namespace).execute();
+            }
+            case "statefulset" -> {
+                return appsApi.readNamespacedStatefulSetScale(scaleName, namespace).execute();
+            }
+            case "replicaset" -> {
+                return appsApi.readNamespacedReplicaSetScale(scaleName, namespace).execute();
+            }
+            default -> throw new IllegalArgumentException("Kind not supported: " + kind);
+        }
+    }
+
+    public boolean waitForReplicas(int timeout, int interval) throws InterruptedException {
+        long elapsed = 0;
+        while (elapsed < timeout) {
+            try {
+                V1Scale scale = readScale();
+                Integer current = scale.getStatus().getReplicas();
+                if (current == this.replicas) {
+                    return true;
+                }
+            } catch (ApiException e) {
+                // Ignore and retry
+            }
+            TimeUnit.SECONDS.sleep(interval);
+            elapsed += interval;
+        }
+        return false;
+    }
+}

--- a/sirio-controller/src/main/java/org/unifi/comunication/InterArrivalKafkaConsumer.java
+++ b/sirio-controller/src/main/java/org/unifi/comunication/InterArrivalKafkaConsumer.java
@@ -1,21 +1,24 @@
 package org.unifi.comunication;
 
 // Required imports for Kafka
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.unifi.api.K8sScaler;
+import org.unifi.model.GenericSplineBuilder;
 
-// Jackson imports for JSON parsing
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.unifi.model.*;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Properties;
-import java.util.List;
-import java.util.ArrayList;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1Scale;
 
 //with all the methods static, we can call them without creating an instance. In this case
 //it's ok because we only have one consumer for the kafka queue
@@ -26,30 +29,28 @@ public class InterArrivalKafkaConsumer {
     private static KafkaConsumer<String, String> consumer;
     private static GenericSplineBuilder spline;
 
-    
-    public static void autoConfig(){
+    public static void autoConfig() {
 
-         // === CONFIGURATION ===
-        
+        // === CONFIGURATION ===
         // Kafka broker address - use environment variable for Kubernetes
         String bootstrapServers = System.getenv().getOrDefault("KAFKA_BOOTSTRAP_SERVERS", "kafka-service:9092");
-        
+
         // Consumer group ID
         String groupId = System.getenv().getOrDefault("KAFKA_GROUP_ID", "sirio-controller-group");
-        
+
         // Topic name - NOTE: Python publishes to 'inter-arrival-cdf'
         String topic = System.getenv().getOrDefault("KAFKA_TOPIC", "inter-arrival-cdf");
 
         // Properties object to hold all configurations
         Properties properties = new Properties();
-        
+
         // === MANDATORY CONFIGURATIONS ===
         properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-        
+
         // === ADDITIONAL CONFIGURATIONS ===
         properties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         properties.setProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
@@ -61,7 +62,7 @@ public class InterArrivalKafkaConsumer {
         // === CONSUMER CREATION ===
         consumer = new KafkaConsumer<>(properties);
         consumer.subscribe(Collections.singletonList(topic));
-        
+
         System.out.println("Inter-Arrival CDF Consumer started with configuration:");
         System.out.println("  Bootstrap servers: " + bootstrapServers);
         System.out.println("  Group ID: " + groupId);
@@ -70,20 +71,19 @@ public class InterArrivalKafkaConsumer {
 
     }
 
-    public static void start_consuming(){
+    public static void start_consuming() {
 
         // Add shutdown hook for graceful termination
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             System.out.println("\n Shutdown signal received...");
             running = false;
-        }));  
-        
-    
+        }));
+
         // === CONSUMPTION LOOP ===
         try {
             while (running) {
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1000));
-                
+
                 for (ConsumerRecord<String, String> record : records) {
                     System.out.println("\n===  NEW CDF MESSAGE ===");
                     System.out.println("Topic: " + record.topic());
@@ -91,51 +91,46 @@ public class InterArrivalKafkaConsumer {
                     System.out.println("Offset: " + record.offset());
                     System.out.println("Timestamp: " + record.timestamp());
                     System.out.println("Key: " + record.key());
-                    
+
                     // Process the CDF message
                     processPassCDFMessage(record.value());
-                    
+
                     System.out.println("========================\n");
                 }
                 /*
                 Creation of the distribution
                 spline = GenericSpline.builder().CDF(x, y).build();
-                */
+                 */
                 if (records.isEmpty()) {
                     System.out.print(".");
                     System.out.flush();
                 }
             }
-            
+
         } catch (Exception e) {
             System.err.println(" Error in consumer: " + e.getMessage());
-            e.printStackTrace();
         } finally {
             System.out.println("\n Closing consumer...");
             consumer.close();
         }
 
     }
-    
-    
 
     // Method to process the CDF message from Kafka queue
     private static void processPassCDFMessage(String messageValue) {
         try {
             System.out.println("Processing CDF message...");
             System.out.println("Raw JSON: " + messageValue);
-            
-            KafkaMessage message = objectMapper.readValue(messageValue, KafkaMessage.class);
-            
-            // === EXTRACT ALL FIELDS ===
 
+            KafkaMessage message = objectMapper.readValue(messageValue, KafkaMessage.class);
+
+            // === EXTRACT ALL FIELDS ===
             long timestamp = message.timestamp;
             String queueName = message.queue_name;
             int totalSamples = message.total_samples;
             int cdfPoints = message.cdf_points;
             List<Double> cdfX = message.cdf_x;
             List<Double> cdfY = message.cdf_y;
-
 
             //passing of consumed data
             spline.CDF(cdfX, cdfY);
@@ -144,7 +139,6 @@ public class InterArrivalKafkaConsumer {
             List<Double> interArrivalTimes = new ArrayList<>(cdfX);
             List<Double> cdfValues = new ArrayList<>(cdfY);
 
-            
             // === PRINT EXTRACTED DATA ===
             System.out.println("Extracted CDF Data:");
             System.out.println("  Timestamp: " + timestamp + " (" + new java.util.Date(timestamp) + ")");
@@ -153,14 +147,36 @@ public class InterArrivalKafkaConsumer {
             System.out.println("  CDF Points: " + cdfPoints);
             System.out.println("  Inter-arrival times count: " + interArrivalTimes.size());
             System.out.println("  CDF values count: " + cdfValues.size());
-            
-            
+
             System.out.println(" CDF message processed successfully!");
-            
+
+            K8sScaler scaler = K8sScaler.getInstance();
+
+            if (scaler.getScaleName() != null && !scaler.getScaleName().isEmpty()) {
+                try {
+                    scaler.scaleWorkload();
+                    System.out.println("\nRequired scaling: " + scaler.getKind() + " '" + scaler.getScaleName() + "' -> replicas = " + scaler.getReplicas());
+
+                    boolean ok = scaler.waitForReplicas(60, 2);
+                    if (ok) {
+                        System.out.println("Replica target achieved.");
+                    } else {
+                        try {
+                            V1Scale scale = scaler.readScale();
+                            System.out.println("Timeout: current replicas = " + scale.getStatus().getReplicas() + ", target = " + scaler.getReplicas());
+                        } catch (ApiException e) {
+                            System.err.println("Failed to read scale after timeout: " + e.getResponseBody());
+                        }
+                    }
+
+                } catch (Exception e) {
+                    System.err.println("Error while trying to scale: " + e.getMessage());
+                }
+            }
+
         } catch (Exception e) {
             System.err.println(" Error processing CDF message: " + e.getMessage());
-            e.printStackTrace();
             System.err.println("Raw message was: " + messageValue);
         }
-    } 
+    }
 }

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,7 @@ docker build -t oris-python-service:latest ./service/
 echo "==> Building inter-arrival collector image"
 docker build -t inter-arrival-collector:latest ./inter-arrival-collector/
 echo "==> ☕ Building Java sirio-controller image"
-docker build -t sirio-controller:latest ./sirio-controller/
+docker build -t sirio-controller:latest --build-arg SKIP_TESTS=true ./sirio-controller/
 echo "==> Loading images into Minikube"
 minikube image load oris-python-service:latest
 minikube image load inter-arrival-collector:latest


### PR DESCRIPTION
- Changed Kafka host in InterArrivalCollector to a simplified address.
- Increased storage size from 1Gi to 5Gi in kafka.yaml.
- Updated service.yaml to scale replicas from 1 to 5.
- Refactored Dockerfile for sirio-controller to improve build efficiency and added health checks.
- Added Kubernetes client dependency in pom.xml.
- Implemented K8sScaler class for managing Kubernetes scaling operations.
- Enhanced InterArrivalKafkaConsumer to include scaling logic based on consumed messages.
- Modified start.sh to skip tests during the Docker build process.